### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/juliencoqueret/d9822152-9194-4987-bffc-11d542ff5542/249526f6-ac92-4032-ade8-a1f97dc9cd0d/_apis/work/boardbadge/85049c8e-8159-4b24-a2a1-568b98cc1c9a)](https://dev.azure.com/juliencoqueret/d9822152-9194-4987-bffc-11d542ff5542/_boards/board/t/249526f6-ac92-4032-ade8-a1f97dc9cd0d/Microsoft.RequirementCategory)
 PolishMyXaml (ReSharper Plugin)
 ======================
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#88](https://dev.azure.com/juliencoqueret/d9822152-9194-4987-bffc-11d542ff5542/_workitems/edit/88). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.